### PR TITLE
Do not create query string from undefined params

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
@@ -32,7 +32,7 @@ class CrunchbaseApi {
     {{/pathParams}}
     // add query string values to path
     const queryParams = {};
-    {{#queryParams}}queryParams.{{baseName}} = {{paramName}};
+    {{#queryParams}}if ({{paramName}} !== undefined) queryParams.{{baseName}} = {{paramName}};
     {{/queryParams}}path += createQueryString(queryParams);
 
     const headers = {};


### PR DESCRIPTION
Fixes bug where undefined query params were being added to the path query string.