### PR TITLE
Handle case where login fails

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
@@ -80,7 +80,8 @@ class Client {
   updateSession(res, method) {
     switch(method) {
       case "POST":
-        this.setSession(res);
+        const okStatus = /^2\d{2}$/;
+        if (okStatus.test(res)) this.setSession(res);
         break;
       case "DELETE":
         this.clearSession();


### PR DESCRIPTION
I was forgetting to handle the case where `postCbSessions` comes back with a non-2XX response.