### PR TITLE
Use string literal instead of path from res.request

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
@@ -63,8 +63,7 @@ class Client {
         request(options)
         .then(res => {
           // Update the session if necessary
-          const path = res.request.uri.path;
-          if (path === "/cb/sessions" || path === "/cb/users") this.updateSession(res, "{{httpMethod}}");
+          if ("{{{path}}}" === "/cb/sessions" || "{{{path}}}" === "/cb/users") this.updateSession(res, "{{httpMethod}}");
           // Reset delay back to zero
           this.delay = 0;
           resolve(res);
@@ -113,12 +112,11 @@ class Client {
    * Gets user from a POST /cb/sessions response.
    */
   getUser(res) {
-    const path = res.request.uri.path;
-    if (path === "/cb/sessions") {
+    if ("{{{path}}}" === "/cb/sessions") {
       if (!(res && res.body && res.body.user))
         throw new ClientError("Could not update session due to malformed response body.");
       return res.body.user;
-    } else if (path === "/cb/users")  {
+    } else if ("{{{path}}}" === "/cb/users")  {
       if (!(res && res.body))
         throw new ClientError("Could not update session due to malformed response body.");
       return res.body;


### PR DESCRIPTION
`path.request.uri.path` included everything after the domain, including the `/v4/` string.