### PR TITLE
Handle request errors by rejecting

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
@@ -66,6 +66,8 @@ class Client {
           // Reset delay back to zero
           this.delay = 0;
           resolve(res);
+        }, err => {
+          reject(`Request failed: ${err}`);
         });
       }, this.delay);
     });


### PR DESCRIPTION
We should be handling `RequestError`s to prevent behavior like [this](https://jenkins.crunchbase.io/view/integration%20test/job/integration-tests-develop/6276/console) in Jenkins:

```
 List service
Unhandled rejection RequestError: Error: ESOCKETTIMEDOUT
    at new RequestError (/crunchbase/integration-tests/node_modules/request-promise-core/lib/errors.js:14:15)
    at Request.plumbing.callback (/crunchbase/integration-tests/node_modules/request-promise-core/lib/plumbing.js:87:29)
    at Request.RP$callback [as _callback] (/crunchbase/integration-tests/node_modules/request-promise-core/lib/plumbing.js:46:31)
    at self.callback (/crunchbase/integration-tests/node_modules/request/request.js:186:22)
    at emitOne (events.js:115:13)
    at Request.emit (events.js:210:7)
    at ClientRequest.<anonymous> (/crunchbase/integration-tests/node_modules/request/request.js:816:16)
    at Object.onceWrapper (events.js:312:19)
    at emitNone (events.js:105:13)
    at ClientRequest.emit (events.js:207:7)
    at Socket.emitTimeout (_http_client.js:720:34)
    at Object.onceWrapper (events.js:312:19)
    at emitNone (events.js:105:13)
    at Socket.emit (events.js:207:7)
    at Socket._onTimeout (net.js:401:8)
    at ontimeout (timers.js:488:11)
    at tryOnTimeout (timers.js:323:5)
    at Timer.listOnTimeout (timers.js:283:5)
TESTS SUCCEEDED
```