### PR TITLE
CB-14368 Add XSRF-TOKEN to request headers

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
@@ -86,8 +86,17 @@ function getRequestOptions(path, method, headers, body, session) {
     body: body,
   };
 
-  if (session && session.cookies)
+  if (session && session.cookies) {
     options.jar = session.cookies
+
+    var xsrfCookie = session.cookies.getCookies(path).find(function(cookie) {
+      return cookie.key == "XSRF-TOKEN";
+    });
+
+    if (xsrfCookie) {
+      headers["X-XSRF-TOKEN"] = decodeURIComponent(xsrfCookie.value);
+    }
+  }
 
   return options;
 }

--- a/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/client.mustache
@@ -87,14 +87,14 @@ function getRequestOptions(path, method, headers, body, session) {
   };
 
   if (session && session.cookies) {
-    options.jar = session.cookies
+    options.jar = session.cookies;
 
     var xsrfCookie = session.cookies.getCookies(path).find(function(cookie) {
       return cookie.key == "XSRF-TOKEN";
     });
 
     if (xsrfCookie) {
-      headers["X-XSRF-TOKEN"] = decodeURIComponent(xsrfCookie.value);
+      options.headers["X-XSRF-TOKEN"] = decodeURIComponent(xsrfCookie.value);
     }
   }
 


### PR DESCRIPTION
Injects decoded XSRF-TOKEN in request headers, to pass userservice CSRF validation.