### PR TITLE
CB-20782: Remove dollar signs for double underscore

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2014,14 +2014,6 @@ public class DefaultCodegen {
             word = m.replaceAll(rep);
         }
 
-        // Replace two underscores with $ to support inner classes.
-        p = Pattern.compile("(__)(.)");
-        m = p.matcher(word);
-        while (m.find()) {
-            word = m.replaceFirst("\\$" + m.group(2).toUpperCase());
-            m = p.matcher(word);
-        }
-
         // Remove all underscores
         p = Pattern.compile("(_)(.)");
         m = p.matcher(word);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -20,6 +20,7 @@ import io.swagger.models.properties.StringProperty;
 
 import com.google.common.collect.Sets;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -452,5 +453,29 @@ public class JavaModelTest {
         final CodegenParameter cm = codegen.fromParameter(parameter, null);
 
         Assert.assertNull(cm.allowableValues);
+    }
+
+    @DataProvider(name = "modelNames")
+    public static Object[][] primeNumbers() {
+        return new Object[][] {
+                {"sample", "Sample"},
+                {"sample_name", "SampleName"},
+                {"sample__name", "SampleName"},
+                {"/sample", "Sample"},
+                {"\\sample", "Sample"},
+                {"sample.name", "SampleName"},
+                {"_sample", "Sample"},
+                {"Sample", "Sample"},
+        };
+    }
+
+    @Test(dataProvider = "modelNames", description = "avoid inner class")
+    public void modelNameTest(String name, String expectedName) {
+        final Model model = new ModelImpl();
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        final CodegenModel cm = codegen.fromModel(name, model);
+
+        Assert.assertEquals(cm.name, name);
+        Assert.assertEquals(cm.classname, expectedName);
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
@@ -16,6 +16,7 @@ import io.swagger.models.properties.StringProperty;
 
 import com.google.common.collect.Sets;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class PhpModelTest {
@@ -239,5 +240,28 @@ public class PhpModelTest {
         Assert.assertEquals(cm.vars.size(), 0);
         Assert.assertEquals(cm.imports.size(), 2);
         Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+    }
+
+    @DataProvider(name = "modelNames")
+    public static Object[][] primeNumbers() {
+        return new Object[][] {
+            {"sample", "Sample"},
+            {"sample_name", "SampleName"},
+            {"sample__name", "SampleName"},
+            {"/sample", "Sample"},
+            {"\\sample", "\\Sample"},
+            {"sample.name", "SampleName"},
+            {"_sample", "Sample"},
+        };
+    }
+
+    @Test(dataProvider = "modelNames", description = "avoid inner class")
+    public void modelNameTest(String name, String expectedName) {
+        final Model model = new ModelImpl();
+        final DefaultCodegen codegen = new PhpClientCodegen();
+        final CodegenModel cm = codegen.fromModel(name, model);
+
+        Assert.assertEquals(cm.name, name);
+        Assert.assertEquals(cm.classname, expectedName);
     }
 }


### PR DESCRIPTION
Ticket: [CB-20782]
This removes a strange old pattern from the codegen replaced double underscores w/ a dollar sign, by cherry-picking a merge commit from the swagger-api main branch that addressed this - you can see that branch linked in the commit, since I used their merge commit. Thanks for telling me how to fix this @amakhrov !

Tested the output in this PR by changing the 'branch' argument in `api-generator` - https://github.com/crunchbase/client_app/pull/3308 And it appears as we expect.

The version with wacky dollar signs is here:
https://github.com/crunchbase/client_app/commit/c12278c3c9c7d91e9d860e555dc345faeb0a78be


[CB-20782]: https://crunchbase.atlassian.net/browse/CB-20782

besides actually generating the API, I did no other due diligence or tests on this branch.