### PR TITLE
CB-23170 Support `additionalProperties` with $ref.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -10,6 +10,7 @@ public class CodegenModel {
     public String classFileName;
     public String unescapedDescription;
     public String defaultValue;
+    public String additionalPropertiesType;
     public List<CodegenProperty> vars = new ArrayList<CodegenProperty>();
     public List<String> allowableValues;
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -847,8 +847,7 @@ public class DefaultCodegen {
                 m.dataType = getSwaggerType(p);
             }
             if (impl.getAdditionalProperties() != null) {
-                MapProperty mapProperty = new MapProperty(impl.getAdditionalProperties());
-                addParentContainer(m, name, mapProperty);
+                addAdditionPropertiesToCodeGenModel(m, impl.getAdditionalProperties());
             }
             addVars(m, impl.getProperties(), impl.getRequired());
         }
@@ -1094,6 +1093,11 @@ public class DefaultCodegen {
             setNonArrayMapProperty(property, type);
         }
         return property;
+    }
+
+    protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Property property) {
+        MapProperty mapProperty = new MapProperty(property);
+        addParentContainer(codegenModel, codegenModel.name, mapProperty);
     }
 
     protected void setNonArrayMapProperty(CodegenProperty property, String type) {
@@ -1890,7 +1894,7 @@ public class DefaultCodegen {
         }
     }
 
-    private void addImport(CodegenModel m, String type) {
+    protected void addImport(CodegenModel m, String type) {
         if (type != null && needToImport(type)) {
             if (!type.endsWith("Model")) {
               type = type + "Model";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -91,6 +91,12 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         return m;
     }
 
+    @Override
+    protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Property property) {
+        codegenModel.additionalPropertiesType = getTypeDeclaration(property);
+        addImport(codegenModel, codegenModel.additionalPropertiesType);
+    }
+
     private class EnumEntryLambda extends CustomLambda {
         @Override
         public String formatFragment(String fragment) {

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.ts.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.ts.mustache
@@ -15,6 +15,8 @@
  */
 {{/description}}
 export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
+{{#additionalPropertiesType}}  [key: string]: {{{additionalPropertiesType}}}{{#hasVars}} | any{{/hasVars}};
+{{/additionalPropertiesType}}
 {{#vars}}   {{name}}{{^required}}?{{/required}}: {{#isEnum}}{{classname}}.{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};  // {{#description}}{{{description}}}{{/description}}
 {{/vars}}
 }


### PR DESCRIPTION
Ticket: [CB-23170](https://crunchbase.atlassian.net/browse/CB-23170)

Implementation is based on the latest openapi-generator for typescript-angular. So this particular patch (hopefully) should not add difficulties when eventually upgrading the generator.

**Problem solved**
It solves only the problem with emitting illegal TS. Now instead of
```
export interface FieldValuesBoundsLabelsModel extends null<String, any> {}
```
it emits
```
export interface FieldValuesBoundsLabelsModel {
  [key: string]: any
}
```

**Problem remained (and just worked around)**
However, the other problem - emitting `any` instead of the exact shape - is preserved, it seems to be a separate bug.
I'm not fixing it currently. Instead, a workaround is to extract additional properties shape into a separate model:
```
FieldValuesBoundsLabels:
    type: object
    additionalProperties:
      $ref: '#/definitions/FieldValuesBoundsLabelsAdditional'

FieldValuesBoundsLabelsAdditional:
    type: object
    properties:
      min_label:
        type: string
      max_label:
        type: string
```
This results in
```
export interface FieldValuesBoundsLabelsModel {
  [key: string]: FieldValuesBoundsLabelsAdditionalModel;
}

export interface FieldValuesBoundsLabelsAdditionalModel {
   min_label?: string;  //
   max_label?: string;  //
}
```